### PR TITLE
fix(fir): steam notifications location

### DIFF
--- a/dot_config/niri/config.kdl_fir
+++ b/dot_config/niri/config.kdl_fir
@@ -359,6 +359,12 @@ window-rule {
     open-floating true
 }
 
+// Move steam notifications to bottom right corner
+window-rule {
+    match app-id="steam" title=r#"^notificationtoasts_\d+_desktop$"#
+    default-floating-position x=10 y=10 relative-to="bottom-right"
+}
+
 // Example: block out two password managers from screen capture.
 // (This example rule is commented out with a "/-" in front.)
 /-window-rule {


### PR DESCRIPTION
steam does not use regular notifications bus.
Need to manually move notifications to bottom right corner.