### PR TITLE
fix(firejail): integration with vscode cli

### DIFF
--- a/home/.chezmoiscripts/run_onchange_21-install-pkgs.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_21-install-pkgs.sh.tmpl
@@ -18,4 +18,7 @@ wget -qO- {{ . | quote }} > /tmp/pkg.deb && sudo dpkg -i /tmp/pkg.deb && rm -rf 
 brew install {{ . }}
 {{- end }}
 
+# Enable firejail
+sudo firecfg
+
 {{- end }}

--- a/home/dot_omz/code.zsh.tmpl
+++ b/home/dot_omz/code.zsh.tmpl
@@ -3,6 +3,10 @@
 # Technically this is set in niri config, but I also need to add it here since
 # I launch VSCode from the terminal.
 code () {
-  DISPLAY=:1 /usr/bin/code "$@"
+  DISPLAY=:1 /usr/local/bin/code "$@" > /dev/null 2>&1 & disown
+}
+{{- else }}
+code () {
+  /usr/local/bin/code "$@" > /dev/null 2>&1 & disown
 }
 {{- end }}


### PR DESCRIPTION
Firejail spits out a bunch of logs and keeps the process open within the shell.

This fixes that by redirecting logs and removing process from current shell.

Firejail will automatically cleanup after the attached VSCode instance is closed.