### PR TITLE
fix(firejail): refactor vscode integration

### DIFF
--- a/home/dot_omz/code.zsh.tmpl
+++ b/home/dot_omz/code.zsh.tmpl
@@ -3,10 +3,10 @@
 # Technically this is set in niri config, but I also need to add it here since
 # I launch VSCode from the terminal.
 code () {
-  DISPLAY=:1 /usr/local/bin/code "$@" > /dev/null 2>&1 & disown
+  (firejail --quiet --env=DISPLAY=:1 /usr/bin/code "$@" & disown) > /dev/null 2>&1
 }
 {{- else }}
 code () {
-  /usr/local/bin/code "$@" > /dev/null 2>&1 & disown
+  (firejail --quiet /usr/bin/code "$@" & disown) > /dev/null 2>&1
 }
 {{- end }}


### PR DESCRIPTION
Use original VSCode binary instead and manually wrap with firejail.