### PR TITLE
fix(firejail): allow vscode to access host network

### DIFF
--- a/home/dot_config/firejail/code.local
+++ b/home/dot_config/firejail/code.local
@@ -1,0 +1,2 @@
+# Allow access to host network
+net host


### PR DESCRIPTION
Unfortunately I can't test my apps locally without allowing local network access...

Maybe consider creating a custom profile later on.