### PR TITLE
feat(birch): use non-brew pnpm and nvm

### DIFF
--- a/home/dot_config/firejail/codium.local
+++ b/home/dot_config/firejail/codium.local
@@ -1,2 +1,5 @@
 # Allow access to host network
 net host
+
+# Allow access to pnpm
+noblacklist ${HOME}/.local/share/pnpm

--- a/home/dot_omz/paths.zsh.tmpl
+++ b/home/dot_omz/paths.zsh.tmpl
@@ -36,8 +36,8 @@ export PATH=$PATH:/usr/local/go/bin
 
 # nvm
 export NVM_DIR="$HOME/.nvm"
-  [ -s "$HOMEBREW_PREFIX/opt/nvm/nvm.sh" ] && \. "$HOMEBREW_PREFIX/opt/nvm/nvm.sh"  # This loads nvm
-  [ -s "$HOMEBREW_PREFIX/opt/nvm/etc/bash_completion.d/nvm" ] && \. "$HOMEBREW_PREFIX/opt/nvm/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 # nvm end
 
 # pnpm

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -21,9 +21,14 @@ eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
 # load a random theme each time Oh My Zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
-# ! NOTE: We are using oh-my-posh as our theme manager.
-eval "$(oh-my-posh init --config $HOME/.config/oh-my-posh/catppuccin.omp.json zsh)"
+# ! NOTE: We are using oh-my-posh as our theme manager. But if we don't find it, fallback to omz theme.
 ZSH_THEME=""
+if command -v oh-my-posh >/dev/null 2>&1; then
+  eval "$(oh-my-posh init --config $HOME/.config/oh-my-posh/catppuccin.omp.json zsh)"
+else
+  # Fallback to a default Oh My Zsh theme
+  ZSH_THEME="agnoster"  # or any other theme
+fi
 
 # Set list of themes to pick from when loading at random
 # Setting this variable when ZSH_THEME=random will cause zsh to load


### PR DESCRIPTION
I can't get firejail to work with linuxbrew. I think partially due to linuxbrew getting installed at /home/linuxbrew
and firejail sees /home/USER as root.

So - we are switching to using pnpm and nvm that are installed on regular system.