### PR TITLE
fix(shell): errors from firejail and codium

### DIFF
--- a/home/dot_omz/themes/example.zsh-theme
+++ b/home/dot_omz/themes/example.zsh-theme
@@ -1,6 +1,0 @@
-# Put your custom themes in this folder.
-# See: https://github.com/ohmyzsh/ohmyzsh/wiki/Customization#overriding-and-adding-themes
-#
-# Example:
-
-PROMPT="%{$fg[red]%}%n%{$reset_color%}@%{$fg[blue]%}%m %{$fg[yellow]%}%~ %{$reset_color%}%% "

--- a/home/dot_omz/themes/oxide.zsh-theme
+++ b/home/dot_omz/themes/oxide.zsh-theme
@@ -1,0 +1,74 @@
+# Oxide theme for Zsh
+#
+# Author: Diki Ananta <diki1aap@gmail.com>
+# Repository: https://github.com/dikiaap/dotfiles
+# License: MIT
+
+# Prompt:
+# %F => Color codes
+# %f => Reset color
+# %~ => Current path
+# %(x.true.false) => Specifies a ternary expression
+#   ! => True if the shell is running with root privileges
+#   ? => True if the exit status of the last command was success
+#
+# Git:
+# %a => Current action (rebase/merge)
+# %b => Current branch
+# %c => Staged changes
+# %u => Unstaged changes
+#
+# Terminal:
+# \n => Newline/Line Feed (LF)
+
+setopt PROMPT_SUBST
+
+autoload -U add-zsh-hook
+autoload -Uz vcs_info
+
+# Use True color (24-bit) if available.
+if [[ "${terminfo[colors]}" -ge 256 ]]; then
+    oxide_turquoise="%F{116}"
+    oxide_orange="%F{215}"
+    oxide_red="%F{168}"
+    oxide_limegreen="%F{114}"
+    oxide_base="%F{141}"
+else
+    oxide_turquoise="%F{cyan}"
+    oxide_orange="%F{yellow}"
+    oxide_red="%F{red}"
+    oxide_limegreen="%F{green}"
+    oxide_base="%F{green}"
+fi
+
+# Reset color.
+oxide_reset_color="%f"
+
+# VCS style formats.
+FMT_UNSTAGED="%{$oxide_reset_color%} %{$oxide_orange%}●"
+FMT_STAGED="%{$oxide_reset_color%} %{$oxide_limegreen%}✚"
+FMT_ACTION="(%{$oxide_limegreen%}%a%{$oxide_reset_color%})"
+FMT_VCS_STATUS="on %{$oxide_turquoise%} %b%u%c%{$oxide_reset_color%}"
+
+zstyle ':vcs_info:*' enable git svn
+zstyle ':vcs_info:*' check-for-changes true
+zstyle ':vcs_info:*' unstagedstr    "${FMT_UNSTAGED}"
+zstyle ':vcs_info:*' stagedstr      "${FMT_STAGED}"
+zstyle ':vcs_info:*' actionformats  "${FMT_VCS_STATUS} ${FMT_ACTION}"
+zstyle ':vcs_info:*' formats        "${FMT_VCS_STATUS}"
+zstyle ':vcs_info:*' nvcsformats    ""
+zstyle ':vcs_info:git*+set-message:*' hooks git-untracked
+
+# Check for untracked files.
++vi-git-untracked() {
+    if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == 'true' ]] && \
+            git status --porcelain | grep --max-count=1 '^??' &> /dev/null; then
+        hook_com[staged]+="%{$oxide_reset_color%} %{$oxide_red%}●"
+    fi
+}
+
+# Executed before each prompt.
+add-zsh-hook precmd vcs_info
+
+# Oxide prompt style.
+PROMPT=$'\n%{$oxide_base%}%~%{$oxide_reset_color%} ${vcs_info_msg_0_}\n%(?.%{%F{white}%}.%{$oxide_red%})%(!.#.❯)%{$oxide_reset_color%} '

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -9,12 +9,14 @@ export ZSH="$HOME/.oh-my-zsh"
 # homebrew
 {{ $brew_prefix := includeTemplate "homebrew" (dict "os" .chezmoi.os "arch" .chezmoi.arch) }}
 export HOMEBREW_PREFIX={{- $brew_prefix | quote }}
-export HOMEBREW_CELLAR="$HOMEBREW_PREFIX/Cellar";
-export HOMEBREW_REPOSITORY="$HOMEBREW_PREFIX/Homebrew";
-export PATH="$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin${PATH+:$PATH}";
-export INFOPATH="$HOMEBREW_PREFIX/share/info:${INFOPATH:-}";
-fpath=($HOMEBREW_PREFIX/share/zsh/site-functions $fpath)
-eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
+if [[ -d $HOMEBREW_PREFIX ]]; then
+  export HOMEBREW_CELLAR="$HOMEBREW_PREFIX/Cellar";
+  export HOMEBREW_REPOSITORY="$HOMEBREW_PREFIX/Homebrew";
+  export PATH="$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin${PATH+:$PATH}";
+  export INFOPATH="$HOMEBREW_PREFIX/share/info:${INFOPATH:-}";
+  fpath=($HOMEBREW_PREFIX/share/zsh/site-functions $fpath)
+  eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
+fi
 # homebrew end
 
 # Set name of the theme to load --- if set to "random", it will
@@ -27,7 +29,7 @@ if command -v oh-my-posh >/dev/null 2>&1; then
   eval "$(oh-my-posh init --config $HOME/.config/oh-my-posh/catppuccin.omp.json zsh)"
 else
   # Fallback to a default Oh My Zsh theme
-  ZSH_THEME="agnoster"  # or any other theme
+  ZSH_THEME="oxide"
 fi
 
 # Set list of themes to pick from when loading at random
@@ -56,37 +58,41 @@ zstyle ':omz:update' mode disabled  # disable automatic updates
 ##########################
 # `fzf`
 ########################## 
-export FZF_BASE="$HOMEBREW_PREFIX/bin/fzf"
-export FZF_DEFAULT_COMMAND='fd --type file --follow --hidden --exclude .git --color=always'
-# https://github.com/catppuccin/fzf
-export FZF_DEFAULT_OPTS=" \
---color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796 \
---color=fg:#CAD3F5,header:#ED8796,info:#C6A0F6,pointer:#F4DBD6 \
---color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#ED8796 \
---color=selected-bg:#494D64 \
---color=border:#6E738D,label:#CAD3F5"
+if [[ -d $HOMEBREW_PREFIX ]]; then
+  export FZF_BASE="$HOMEBREW_PREFIX/bin/fzf"
+  export FZF_DEFAULT_COMMAND='fdfind --type file --follow --hidden --exclude .git'
+  # https://github.com/catppuccin/fzf
+  export FZF_DEFAULT_OPTS=" \
+  --color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796 \
+  --color=fg:#CAD3F5,header:#ED8796,info:#C6A0F6,pointer:#F4DBD6 \
+  --color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#ED8796 \
+  --color=selected-bg:#494D64 \
+  --color=border:#6E738D,label:#CAD3F5"
+fi
 
 ##########################
 # `fzf-tab`
 ########################## 
-# Disable sort when completing `git checkout`
-zstyle ':completion:*:*:git-checkout:*' sort false
-# Set descriptions format to enable group support
-zstyle ':completion:*:descriptions' format '[%d]'
-# set list-colors to enable filename colorizing
-zstyle ':completion:*' list-colors ${(s.:.)LS_COLORS}
-# force zsh not to show completion menu, which allows fzf-tab to capture the unambiguous prefix
-zstyle ':completion:*' menu no
-# preview directory's content with eza when completing cd
-zstyle ':fzf-tab:complete:cd:*' fzf-preview 'eza -1 --color=always $realpath'
-# custom fzf flags
-# NOTE: fzf-tab does not follow FZF_DEFAULT_OPTS by default
-zstyle ':fzf-tab:*' fzf-flags --color=fg:#CAD3F5,fg+:#CAD3F5 --bind=tab:accept
-# To make fzf-tab follow FZF_DEFAULT_OPTS.
-# NOTE: This may lead to unexpected behavior since some flags break this plugin. See Aloxaf/fzf-tab#455.
-zstyle ':fzf-tab:*' use-fzf-default-opts yes
-# switch group using `<` and `>`
-zstyle ':fzf-tab:*' switch-group '<' '>'
+if [[ -d $HOMEBREW_PREFIX ]]; then
+  # Disable sort when completing `git checkout`
+  zstyle ':completion:*:*:git-checkout:*' sort false
+  # Set descriptions format to enable group support
+  zstyle ':completion:*:descriptions' format '[%d]'
+  # set list-colors to enable filename colorizing
+  zstyle ':completion:*' list-colors ${(s.:.)LS_COLORS}
+  # force zsh not to show completion menu, which allows fzf-tab to capture the unambiguous prefix
+  zstyle ':completion:*' menu no
+  # preview directory's content with eza when completing cd
+  zstyle ':fzf-tab:complete:cd:*' fzf-preview 'eza -1 --color=always $realpath'
+  # custom fzf flags
+  # NOTE: fzf-tab does not follow FZF_DEFAULT_OPTS by default
+  zstyle ':fzf-tab:*' fzf-flags --color=fg:#CAD3F5,fg+:#CAD3F5 --bind=tab:accept
+  # To make fzf-tab follow FZF_DEFAULT_OPTS.
+  # NOTE: This may lead to unexpected behavior since some flags break this plugin. See Aloxaf/fzf-tab#455.
+  zstyle ':fzf-tab:*' use-fzf-default-opts yes
+  # switch group using `<` and `>`
+  zstyle ':fzf-tab:*' switch-group '<' '>'
+fi
 
 # Uncomment the following line if pasting URLs and other text is messed up.
 # DISABLE_MAGIC_FUNCTIONS="true"
@@ -128,7 +134,11 @@ ZSH_CUSTOM="$HOME/.omz"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git zoxide eza thefuck fzf fzf-tab)
+plugins=(git zoxide eza thefuck)
+# ! NOTE: Optionally include `fzf` and `fzf-tab` plugins if homebrew is available.
+if [[ -d $HOMEBREW_PREFIX ]]; then
+  plugins+=(fzf fzf-tab)
+fi
 
 # Additional completions.
 # ! NOTE: If you add a new completion, you may need to refresh `.zcompdump` to make it available.


### PR DESCRIPTION
Since we switched to use firejail and codium, there have been lots of errors popping up...

Like not being able to access linuxbrew...
Which impacted stuff like shell themes, fzf, etc.

So we disable them automatically if linuxbrew is not found.

Also fallback to omz theme if we can't use oh-my-posh.