### PR TITLE
fix(codium): stop auto-activating python env

### DIFF
--- a/home/dot_config/VSCodium/User/birch_settings.jsonc
+++ b/home/dot_config/VSCodium/User/birch_settings.jsonc
@@ -5,14 +5,12 @@
   "editor.semanticHighlighting.enabled": true,
   "terminal.integrated.minimumContrastRatio": 1,
   "window.titleBarStyle": "custom",
-  "gopls": {},
   "workbench.productIconTheme": "Tabler",
 
   "terminal.integrated.fontFamily": "'MesloLGS Nerd Font Mono'",
   "editor.fontFamily": "'MesloLGS Nerd Font Mono', monospace",
   "security.workspace.trust.untrustedFiles": "open",
   "editor.guides.bracketPairs": true,
-  "go.toolsManagement.autoUpdate": true,
 
   "editor.indentSize": "tabSize",
   "editor.tabSize": 4,
@@ -22,6 +20,12 @@
   "catppuccin-noctis-icons.hidesExplorerArrows": false,
 
   "telemetry.telemetryLevel": "off",
+
+  // Language extensions
+  "python.terminal.activateEnvironment": false,
+  "python.analysis.typeCheckingMode": "standard",
+  "gopls": {},
+  "go.toolsManagement.autoUpdate": true,
 
   "[tf]": {
     "editor.formatOnSave": true,
@@ -61,7 +65,6 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "python.analysis.typeCheckingMode": "standard",
   "[go]": {
     "editor.insertSpaces": false,
     "editor.formatOnSave": true,

--- a/home/dot_config/VSCodium/User/fir_settings.jsonc
+++ b/home/dot_config/VSCodium/User/fir_settings.jsonc
@@ -5,14 +5,12 @@
   "editor.semanticHighlighting.enabled": true,
   "terminal.integrated.minimumContrastRatio": 1,
   "window.titleBarStyle": "custom",
-  "gopls": {},
   "workbench.productIconTheme": "Tabler",
 
   "terminal.integrated.fontFamily": "'FiraCode Nerd Font Mono'",
   "editor.fontFamily": "'FiraCode Nerd Font Mono',monospace",
   "security.workspace.trust.untrustedFiles": "open",
   "editor.guides.bracketPairs": true,
-  "go.toolsManagement.autoUpdate": true,
 
   "editor.indentSize": "tabSize",
   "editor.tabSize": 4,
@@ -22,6 +20,11 @@
   "catppuccin-noctis-icons.hidesExplorerArrows": false,
 
   "telemetry.telemetryLevel": "off",
+
+  // Language extensions
+  "python.terminal.activateEnvironment": false,
+  "gopls": {},
+  "go.toolsManagement.autoUpdate": true,
 
   "[tf]": {
     "editor.formatOnSave": true,


### PR DESCRIPTION
Let `nix-direnv` handle environment activations.