### PR TITLE
fix(jj): explicitly set default cmd to log

### DIFF
--- a/home/dot_config/VSCodium/User/fir_settings.jsonc
+++ b/home/dot_config/VSCodium/User/fir_settings.jsonc
@@ -74,5 +74,17 @@
   "[postcss]": {
     "editor.tabSize": 2,
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[python]": {
+    "diffEditor.ignoreTrimWhitespace": false,
+    "editor.defaultColorDecorators": "never",
+    "editor.formatOnType": true,
+    "editor.quickSuggestions": {
+      "strings": true
+    },
+    "editor.wordBasedSuggestions": "off",
+    "gitlens.codeLens.symbolScopes": [
+      "!Module"
+    ]
   }
 }

--- a/home/dot_config/jj/config.toml
+++ b/home/dot_config/jj/config.toml
@@ -3,6 +3,7 @@ name = "Yiping (Allison)"
 email = "32723567+yiping-allison@users.noreply.github.com"
 
 [ui]
+default-command = "log"
 color = "always"
 editor = "nvim"
 paginate = "auto"

--- a/misc/vscode/codium-extensions.txt
+++ b/misc/vscode/codium-extensions.txt
@@ -5,7 +5,6 @@ arrterian.nix-env-selector
 bradlc.vscode-tailwindcss
 catppuccin.catppuccin-vsc
 csstools.postcss
-detachhead.basedpyright
 docker.docker
 eamodio.gitlens
 editorconfig.editorconfig


### PR DESCRIPTION
Disable auto-message saying to run help on `jj`.

Also - automatic sync of codium settings.
