### PR TITLE
fix(firejail): allow execution from /tmp

### DIFF
--- a/home/dot_config/VSCodium/User/birch_settings.jsonc
+++ b/home/dot_config/VSCodium/User/birch_settings.jsonc
@@ -21,10 +21,8 @@
 
   // Telemetry
   "telemetry.telemetryLevel": "off",
-  "telemetry.enableCrashReporter": false,
   "telemetry.feedback.enabled": false,
-  "update.enableWindowsBackgroundUpdates": true,
-  "update.mode": "autoUpdate",
+  "update.mode": "default",
   "workbench.enableExperiments": false,
   "workbench.settings.enableNaturalLanguageSearch": false,
 

--- a/home/dot_config/VSCodium/User/fir_settings.jsonc
+++ b/home/dot_config/VSCodium/User/fir_settings.jsonc
@@ -21,10 +21,8 @@
 
   // Telemetry
   "telemetry.telemetryLevel": "off",
-  "telemetry.enableCrashReporter": false,
   "telemetry.feedback.enabled": false,
-  "update.enableWindowsBackgroundUpdates": true,
-  "update.mode": "autoUpdate",
+  "update.mode": "default",
   "workbench.enableExperiments": false,
   "workbench.settings.enableNaturalLanguageSearch": false,
 

--- a/home/dot_config/firejail/codium.local
+++ b/home/dot_config/firejail/codium.local
@@ -3,3 +3,7 @@ net host
 
 # Allow access to pnpm
 noblacklist ${HOME}/.local/share/pnpm
+
+# Allow /tmp directory execution
+# Needed to run tests within the editor
+ignore noexec /tmp


### PR DESCRIPTION
I can't run go tests in the editor. Turns out it was because go builds test executables under `/tmp`, and firejail blocks running executables from there.