### PR TITLE
fix: disable steamtinkerlaunch symlink

### DIFF
--- a/home/dot_config/steamtinkerlaunch/default_template.conf
+++ b/home/dot_config/steamtinkerlaunch/default_template.conf
@@ -370,4 +370,3 @@ STL_VKD3D_TEST_PLATFORM="none"
 STL_VKD3D_TEST_BUG="none"
 ## If profiling is enabled in the build, a profiling block is emitted to .
 STL_VKD3D_PROFILE_PATH="none"
-

--- a/home/dot_config/steamtinkerlaunch/symlink_default_template.conf.tmpl
+++ b/home/dot_config/steamtinkerlaunch/symlink_default_template.conf.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.sourceDir }}/dot_config/steamtinkerlaunch/default_template


### PR DESCRIPTION
Some weird things are going on with the steamtinkerlaunch config with the symlink.

It's messing with configs, so just copy the static file over.