### PR TITLE
fix(jj): use proper diff formatter

### DIFF
--- a/home/dot_config/private_jj/config.toml.tmpl
+++ b/home/dot_config/private_jj/config.toml.tmpl
@@ -8,7 +8,7 @@ color = "always"
 editor = "nvim"
 paginate = "auto"
 pager = "delta"
-diff-formatter = "delta"
+diff-formatter = ":git"
 conflict-marker-style = "git"
 log-word-wrap = true
 


### PR DESCRIPTION
jj delta integration requires `:git` as diff formatter.