### PR TITLE
feat(steamtinkerlaunch): add global settings

### DIFF
--- a/home/dot_config/steamtinkerlaunch/global.conf
+++ b/home/dot_config/steamtinkerlaunch/global.conf
@@ -1,0 +1,256 @@
+## config Version: v14.0.20250602
+##########################
+## The language to use for the GUI and general descriptions
+STLLANG="english"
+## Skip dependency check for internally used programs
+SKIPINTDEPCHECK="0"
+## yad command
+YAD="/usr/local/bin/yad"
+## The download directory for custom Proton archives
+CUSTPROTDLDIR="STLCFGDIR/downloads/proton/custom"
+## The extract directory for downloaded custom Proton archives
+CUSTPROTEXTDIR="STLCFGDIR/proton/custom"
+## Extract custom Proton in compatibilitytools.d
+CUPROTOCOMPAT="1"
+## The download directory for Wine archives
+WINEDLDIR="STLCFGDIR/downloads/wine"
+## The extract directory for downloaded Wine archives
+WINEEXTDIR="STLCFGDIR/wine"
+## enable Global Wine DPI scaling value set below - When disabled, wil revert to Wine default of '96'
+USEGLOBALWINEDPI="0"
+## set a Wine DPI value to enforce for all games - Default is '96' as set by Wine
+GLOBALWINEDPI="96"
+## Automatically use last used Proton version when configured one is not found
+AUTOLASTPROTON="1"
+## The path where strace logs are stored
+STRACEDIR="STLCFGDIR/logs/steamtinkerlaunch"
+## The path where the SteamTinkerLaunch logs are stored
+LOGDIR="STLCFGDIR/logs/steamtinkerlaunch"
+## The log level of the logfiles - 0=none, 1=less, 2=all
+LOGLEVEL="2"
+## Reset game log on every new launch
+RESETLOG="1"
+## The text editor used for editing config files manually
+STLEDITOR="/usr/bin/gedit"
+## Give up asking if the settings shall be opened per game after n rejected requesters
+MAXASK="3"
+## The web browser used to optionally open URLs
+BROWSER="/usr/bin/firefox"
+## Enable notifier
+USENOTIFIER="1"
+## The command used for the notifier
+NOTY="/usr/bin/notify-send"
+## Command line arguments for the used notifier
+NOTYARGS="-i /dev/shm/steamtinkerlaunch/steamtinkerlaunch-steam-checked.png -a SteamTinkerLaunch"
+## The command used for network monitoring
+NETMON="/usr/bin/netstat"
+## The command line arguments used for network monitor
+NETOPTS="-taucp -W"
+## The path where network monitor logs are stored
+NETMONDIR="STLCFGDIR/logs/steamtinkerlaunch"
+## The Side-by-Side Stereo3D VR player executable
+VRVIDEOPLAYER="none"
+## Path where global Side-by-Side tweak files are stored
+GLOBALSBSTWEAKS="/usr/share/steamtinkerlaunch/sbstweaks"
+## Path where global tweak files are stored
+GLOBALTWEAKS="/usr/share/steamtinkerlaunch/tweaks"
+## Path where global Steam collection tweak files are stored
+GLOBALCOLLECTIONDIR="/usr/share/steamtinkerlaunch/collections"
+## Path where global misc files are stored
+GLOBALMISCDIR="/usr/share/steamtinkerlaunch/misc"
+## Path where global evaluatorscripts are stored
+GLOBALEVALDIR="/usr/share/steamtinkerlaunch/eval"
+## Path where global language files are stored
+GLOBALSTLLANGDIR="/usr/share/steamtinkerlaunch/lang"
+## Path where global resolution templates are stored
+GLOBALSTLGUIDIR="/usr/share/steamtinkerlaunch/guicfgs"
+## The Boxtron command
+BOXTRONCMD="/usr/share/boxtron/run-dosbox"
+## The command line arguments used for Boxtron
+BOXTRONARGS="--wait-before-run"
+## The Roberta executable
+ROBERTACMD="/home/allison/.steam/debian-installation/compatibilitytools.d/roberta/run-vm"
+## The command line arguments used for Roberta
+ROBERTAARGS="--wait-before-run"
+## The Luxtorpeda executable
+LUXTORPEDACMD="/home/allison/.steam/debian-installation/compatibilitytools.d/luxtorpeda/luxtorpeda.sh"
+## The command line arguments used for Luxtorpeda
+LUXTORPEDAARGS="wait-before-run"
+## Allow download of ReShade source files
+DOWNLOAD_RESHADE="1"
+## The version of the ReShade setup to download
+RSVERS="5.9.1"
+## Auto update ReShade to the latest version
+AUTOBUMPRESHADE="0"
+## The directory where ReShade components are stored and loaded
+RESHADESRCDIR="STLCFGDIR/downloads/reshade"
+## The filename of the 64bit d3dcompiler_47.dll
+D3D47_64="d3dcompiler_47_64.dll"
+## The filename of the 32bit d3dcompiler_47.dll
+D3D47_32="d3dcompiler_47_32.dll"
+## The filename of the 64bit ReShade DLL
+RS_64="ReShade64.dll"
+## The filename of the 32bit ReShade DLL
+RS_32="ReShade32.dll"
+## The filename of the 64bit ReShade JSON
+RS_64_VK="ReShade64.json"
+## The filename of the 32bit ReShade JSON
+RS_32_VK="ReShade32.json"
+## Allow pulling and updating shaders if required
+DLSHADER="1"
+## Automatically save current settings menu resolution on exit
+SAVESETSIZE="1"
+## The start menu used
+STARTMENU="Menu"
+## The font size used in the headlines
+HEADLINEFONT="larger"
+## run Yad with XWayland with GDK_BACKEND=x11, will do nothing outside of a Wayland session - will take effect after restarting SteamTinkerLaunch
+YADFORCEXWAYLAND="0"
+## DESC_USERSSPEKVERS
+USERSSPEKVERS="1"
+## Version of ReShade to use when installing ReShade as a SpecialK Plugin
+RSSPEKVERS="5.4.2"
+## Use window decoration for all windows - Note that disabling window decorations does not work on Wayland
+USEWINDECO="1"
+## Use the tray icon
+USETRAYICON="1"
+## Show game pictures
+USEGAMEPICS="1"
+## Use custom fallback picture instead of the built-in one, if no game picture was found
+USECUSTOMFALLBACKPIC="0"
+## If provided and USECUSTOMFALLBACKPIC is enabled the avatar of the user is used as fallback picture
+GITHUBUSER="none"
+## Download game pictures and game names if missing
+DLGAMEDATA="1"
+## Fetch Steam Deck compatibility information from Steam - Previously fetched compatibility information will be preserved
+DLSTEAMDECKCOMPATINFO="1"
+## Download and show latest ProtonDB rating for the game
+USEPDBRATING="1"
+## Use downloaded cache for ProtonDB rating if not older than X days
+PDBRATINGCACHE="1"
+## Download Winetricks instead of using a system wide installation
+DLWINETRICKS="0"
+## The Proton version used for Vortex
+USEVORTEXPROTON="none"
+## The compatdata directory for the Vortex installation
+VORTEXCOMPDATA="STLCFGDIR/vortex/compatdata"
+## The path where the Vortex installer should be stored
+VORTEXDOWNLOADPATH="STLCFGDIR/vortex/downloads"
+## Use/download the latest Vortex prerelease
+USEVORTEXPRERELEASE="0"
+## run the Vortex installer inside the Steam Linux Runtime (if available) - will NOT be used once Vortex installs .NET 6 and is restarted
+VORTEXUSESLR="1"
+## run Vortex inside the Steam Linux Runtime (if available) - This may cause issues with mod deployment
+VORTEXUSESLR="0"
+## sets Vortex update channel to 'No automatic updates' which can help prevent breakages - if disabled, will set to stable/beta depending on value of 'USEVORTEXPRERELEASE' checkbox
+DISABLEVORTEXAUTOUPDATE="0"
+## if enabled, fresh Vortex installs will use the specified version - If not found, falls back to latest (stable/beta depending on value of 'USEVORTEXPRERELEASE' checkbox)
+USEVORTEXCUSTOMVER="0"
+## The release tag of the Vortex version to install
+VORTEXCUSTOMVER="none"
+## uses the --device-scale-factor flag to set the Vortex GUI scale. Defaults to 1.0, but if you want a larger GUI you can set it to match your display's scale factor (or the largest scale factor, if using multiple across displays)
+VORTEXDEVICESCALEFACTOR="1"
+## When checked, SteamTinkerLaunch won't autocreate Vortex 'stage' directories and they have to be added manually to VORTEXSTAGELIST
+DISABLE_AUTOSTAGES="0"
+## Set 'steamtinkerlaunch icon for non-Steam games by default
+NOSTEAMSTLDEF="0"
+## Your personal SteamGridDB API key used for downloading custom Steam grids
+SGDBAPIKEY="none"
+## Hero enable downloading Hero (banner) artwork from SteamGridDB
+SGDBDLHERO="1"
+## Hero Dimension filter options, in order of priority
+SGDBHERODIMS="3840x1240"
+## Hero Type filter options
+SGDBHEROTYPES="static"
+## Hero Style filter options
+SGDBHEROSTYLES="alternate,blurred,material"
+## Hero NSFW options
+SGDBHERONSFW="any"
+## Hero Humor options
+SGDBHEROHUMOR="any"
+## Hero epilepsy options
+SGDBHEROEPILEPSY="false"
+## Logo enable downloading Logo artwork from SteamGridDB
+SGDBDLLOGO="1"
+## Logo Type filter options
+SGDBLOGOTYPES="static"
+## Logo Style filter options
+SGDBLOGOSTYLES="official,white,black,custom"
+## Logo NSFW options
+SGDBLOGONSFW="any"
+## Logo Humor options
+SGDBLOGOHUMOR="any"
+## Logo epilepsy options
+SGDBLOGOEPILEPSY="false"
+## Boxart enable downloading Boxart (vertical grid) artwork from SteamGridDB
+SGDBDLBOXART="1"
+## Boxart Dimension filter options, in order of priority
+SGDBBOXARTDIMS="600x900"
+## Boxart Type filter options
+SGDBBOXARTTYPES="static"
+## Boxart Style filter options
+SGDBBOXARTSTYLES="alternate,blurred,white_logo,material,no_logo"
+## Boxart NSFW options
+SGDBBOXARTNSFW="any"
+## Boxart Humor options
+SGDBBOXARTHUMOR="any"
+## Boxart epilepsy options
+SGDBBOXARTEPILEPSY="false"
+## Tenfoot enable downloading Tenfoot (Horizontal grid) artwork from SteamGridDB
+SGDBDLTENFOOT="1"
+## Tenfoot Dimension filter options, in order of priority
+SGDBTENFOOTDIMS="920x430,460x215"
+## Tenfoot Type filter options
+SGDBTENFOOTTYPES="static"
+## Tenfoot Style filter options
+SGDBTENFOOTSTYLES="alternate,blurred,white_logo,material"
+## Tenfoot NSFW options
+SGDBTENFOOTNSFW="any"
+## Tenfoot Humor options
+SGDBTENFOOTHUMOR="any"
+## Tenfoot epilepsy options
+SGDBTENFOOTEPILEPSY="false"
+## Download grid directly into Steam grid directory
+SGDBDLTOSTEAM="0"
+## How to handle an already existing grid file
+SGDBHASFILE="skip"
+## Automatic grid download behavior
+SGDBAUTODL="none"
+## Create a GameTitle symlink in 'STLCOMPDAT' for finding a WINEPREFIX easier
+STORECOMPDATTITLE="1"
+## Custom Conty executable
+CUSTCONTY="/home/allison/none"
+## Update downloaded Conty automatically
+UPDATECONTY="1"
+## Log the time played per game
+LOGPLAYTIME="1"
+## The compatdata directory for Depressurizer
+DPRSCOMPDATA="STLCFGDIR/depressurizer/compatdata"
+## The Proton version used for Depressurizer
+USEDPRSPROTON="none"
+## Use VDF symlinks for Depressurizer instead of copying to the original ones
+DPRSUSEVDFSYMLINKS="0"
+## Automatically look for latest Depressurizer version
+DPRSPAUTOUP="0"
+## Automatically look for latest Dependencies version
+DEPSAUTOUP="0"
+## The compatdata directory for the Mod Organizer 2 installation
+MO2COMPDATA="STLCFGDIR/mo2/compatdata"
+## The Proton version used for Mod Organizer 2
+USEMO2PROTON="none"
+## enable using a custom selected ModOrganizer 2 installer executable
+USEMO2CUSTOMINSTALLER="0"
+## path to a custom ModOrganizer 2 installer executable (for example, a custom or development build) to use in place of downloading from GitHub
+MO2CUSTOMINSTALLER="/home/allison/none"
+## The compatdata directory for HedgeModManager to run inside of
+HMMCOMPDATA="STLCFGDIR/hedgemodmanager/compatdata"
+## The Proton version used to run HedgeModManager
+USEHMMPROTON="none"
+## The HedgeModManager version to download
+HMMDLVER="stable"
+## Terminal emulator used f.e. for GDB debugging
+USETERM="none"
+## Terminal emulator command line arguments
+TERMARGS="-e"
+## Enable the libraries autoupdater for the Steam Deck after an STL update
+STEAMDECK_AUTOUP="1"


### PR DESCRIPTION
Needed to make a change to `CUPROTOCOMPAT` so steamtinkerlaunch would share additional
proton versions with steam.