### PR TITLE
revert: "feat(codium): add visualjj to extensions list"

### DIFF
--- a/misc/vscode/codium-extensions.txt
+++ b/misc/vscode/codium-extensions.txt
@@ -41,7 +41,6 @@ redhat.vscode-xml
 rust-lang.rust-analyzer
 streetsidesoftware.code-spell-checker
 tamasfe.even-better-toml
-visualjj.visualjj
 vscodevim.vim
 wayou.vscode-todo-highlight
 zguolee.tabler-icons


### PR DESCRIPTION
Turns out using VisualJJ and `jj` cli concurrently will corrupt commits since VisualJJ also attempts to manage your working commit.
I'll just manage `jj` via CLI.

Refs: yiping-allison/dotfiles#80
