### PR TITLE
feat(fir): remove java from zsh

### DIFF
--- a/home/private_dot_omz/paths.zsh.tmpl
+++ b/home/private_dot_omz/paths.zsh.tmpl
@@ -8,11 +8,6 @@ export PATH=$HOME/.local/bin:$PATH
 export PATH=$PATH:/usr/local/go/bin
 # go end
 
-# java
-export JAVA_HOME="/usr/lib/jvm/jdk-21.0.7+6"
-export PATH="$PATH:$JAVA_HOME/bin"
-# java end
-
 # pnpm
 export PNPM_HOME="{{- .chezmoi.homeDir -}}/.local/share/pnpm"
 case ":$PATH:" in


### PR DESCRIPTION
Use `nix` to manage java installations.